### PR TITLE
Bugfixes for installation and STT

### DIFF
--- a/main.py
+++ b/main.py
@@ -32,6 +32,7 @@ def configure_logger(loglevel):
 FORMAT = pyaudio.paInt16
 CHANNELS = 1
 RATE = 44100
+FRAMES_PER_BUFFER = 1024
 
 
 def _handle_task_result(task):
@@ -55,11 +56,9 @@ async def start_stream(mic_stream, uri):
     extra_headers = {"Authorization": f"Token {os.environ.get('DEEPGRAM_API_KEY')}"}
     logger.debug(uri)
     try:
-        async with websockets.connect(uri, additional_headers=extra_headers) as ws:
+        async with websockets.connect(uri, extra_headers=extra_headers) as ws:
             # see https://websockets.readthedocs.io/en/stable/reference/client.html#websockets.client.WebSocketClientProtocol
             shared_data = {"endstream": False, "agent_ready": False}
-            requestid = ws.response.headers.get("dg-request-id", ws.response.headers)
-            logger.info(f"Request: {requestid}")
 
             async def sender(mic_stream, ws, shared):
                 """Send audio through websocket."""
@@ -67,10 +66,11 @@ async def start_stream(mic_stream, uri):
                 # Start out by sending the settings
                 await ws.send(json.dumps(AGENT_SETTINGS))
                 while True:
+                    piece = mic_stream.read(FRAMES_PER_BUFFER, exception_on_overflow=False)
+
                     if not shared_data.get("agent_ready", False):
                         await asyncio.sleep(0.1)  # wait a little
-                        continue
-                    piece = mic_stream.read(mic_stream.get_read_available())
+                        continue  # Discard audio until agent is ready
 
                     if shared_data["endstream"]:
                         piece = b""  # This will close the connection

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,3 +9,6 @@ dependencies = [
     "pyaudio>=0.2.14",
     "websockets>=15.0.1",
 ]
+
+[tool.setuptools]
+py-modules = ["agent_config", "speaker", "main", "agent_functions"]


### PR DESCRIPTION
- Add config to TOML file so that the pip install works seamlessly
- Avoid audio buffer overflow errors from collecting but not sending audio until after agent is ready. Example error below that was being raised.
```
ERROR    2025-06-02 14:04:33,876 __name__     Exception raised by task = <Task finished name='Task-5' coro=<start_stream.<locals>.sender() done, defined at /Users/julia/code/voice-agent-python-client/main.py:63> exception=OSError(-9981, 'Input overflowed')>
```
----
Example logs working now (continues to log request ID):
```
(venv) (base) voice-agent-python-client % python3 main.py
DEBUG    2025-06-02 14:10:01,980 __name__     wss://agent.deepgram.com/v1/agent/converse
INFO     2025-06-02 14:10:02,177 __name__     Welcome received. Request id: 9e8d63ba-6d5d-4a29-d2fe-47f55bf3d340
INFO     2025-06-02 14:10:02,183 __name__     Conversation text received.  Role: assistant. Content: Hello. My name is Sarah, would you like to hear a story?
INFO     2025-06-02 14:10:02,290 __name__     Settings applied, starting to stream microphone
INFO     2025-06-02 14:10:02,339 __name__     Agent audio done
INFO     2025-06-02 14:10:07,109 __name__     User started speaking.  Stopping speaker
INFO     2025-06-02 14:10:07,633 __name__     Conversation text received.  Role: user. Content: Yes, please.
INFO     2025-06-02 14:10:08,170 __name__     Conversation text received.  Role: assistant. Content: Great!
INFO     2025-06-02 14:10:08,582 __name__     Conversation text received.  Role: assistant. Content: What theme or topic would you like the story to revolve around?
INFO     2025-06-02 14:10:08,748 __name__     Agent audio done
...
```